### PR TITLE
Docker base image set to python:3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.8
 ARG YANG_ID
 ARG YANG_GID
 


### PR DESCRIPTION
- Explicitly set version of python base image to be used

Signed-off-by: Slavomir Mazur <slavomir.mazur@pantheon.tech>