### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,11 @@ python-dateutil==2.8.0
 elasticsearch==6.3.1
 flask-cors==3.0.7
 Flask-WTF==0.14.2
-pytest==5.0
+pytest==6.2.2
 flask==1.0.2
 werkzeug==0.16.1
 flask-oidc==1.4.0
 redis==3.5.3
 gunicorn==20.0.4
 gevent==20.9.0
+pyparsing==2.4.7


### PR DESCRIPTION
This fixes following error which appeared for Python 3.7:
ERROR: httplib2 0.19.0 has requirement pyparsing<3,>=2.4.2, but you'll have pyparsing 2.4.0 which is incompatible.