### PR TITLE
Response headers logic moved to NGINX config

### DIFF
--- a/api/views/ycSearch/ycSearch.py
+++ b/api/views/ycSearch/ycSearch.py
@@ -608,7 +608,6 @@ def get_organizations():
             orgs.add(module['organization'])
     orgs = list(orgs)
     response = make_response(jsonify({'contributors': orgs}), 200)
-    response.headers['Access-Control-Allow-Origin'] = '*'
     return response
 
 

--- a/api/yangCatalogApi.py
+++ b/api/yangCatalogApi.py
@@ -87,8 +87,6 @@ class MyFlask(Flask):
 
     def process_response(self, response):
         response = super().process_response(response)
-        response.headers['Access-Control-Allow-Headers'] = 'Origin, X-Requested-With, Content-Type, Accept, x-auth'
-        response.headers['Access-Control-Request-Headers'] = 'Origin'
         self.create_response_only_latest_revision(response)
         #self.create_response_with_yangsuite_link(response)
 


### PR DESCRIPTION
This resolves #209.
Part of the problem is also solved [HERE](https://github.com/YangCatalog/deployment/issues/42).
Signed-off-by: Slavomir Mazur <slavomir.mazur@pantheon.tech>