### PR TITLE
Add registration time and motivation for users

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -17,7 +17,7 @@ __copyright__ = "Copyright The IETF Trust 2021, All Rights Reserved"
 __license__ = "Apache License, Version 2.0"
 __email__ = "richard.zilincik@pantheon.tech"
 
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, text
 from sqlalchemy.ext.declarative import DeferredReflection
 from sqlalchemy.orm import declarative_base
 
@@ -36,7 +36,6 @@ class BaseUser(DeferredReflection, Base):
     AccessRightsSdo = Column(String(255))
     AccessRightsVendor = Column(String(255))
     Motivation = Column(String(255))
-    RegistrationDatetime = Column(DateTime())
 
 
 class User(BaseUser):
@@ -45,3 +44,4 @@ class User(BaseUser):
 
 class TempUser(BaseUser):
     __tablename__ = 'users_temp'
+    RegistrationDatetime = Column(DateTime)

--- a/api/models.py
+++ b/api/models.py
@@ -35,7 +35,7 @@ class BaseUser(DeferredReflection, Base):
     LastName = Column(String(255))
     AccessRightsSdo = Column(String(255))
     AccessRightsVendor = Column(String(255))
-    Motivation = Column(String(255))
+    RegistrationDatetime = Column(DateTime)
 
 
 class User(BaseUser):
@@ -44,4 +44,4 @@ class User(BaseUser):
 
 class TempUser(BaseUser):
     __tablename__ = 'users_temp'
-    RegistrationDatetime = Column(DateTime)
+    Motivation = Column(String(255))

--- a/api/models.py
+++ b/api/models.py
@@ -17,7 +17,7 @@ __copyright__ = "Copyright The IETF Trust 2021, All Rights Reserved"
 __license__ = "Apache License, Version 2.0"
 __email__ = "richard.zilincik@pantheon.tech"
 
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, DateTime
 from sqlalchemy.ext.declarative import DeferredReflection
 from sqlalchemy.orm import declarative_base
 
@@ -35,6 +35,8 @@ class BaseUser(DeferredReflection, Base):
     LastName = Column(String(255))
     AccessRightsSdo = Column(String(255))
     AccessRightsVendor = Column(String(255))
+    Motivation = Column(String(255))
+    RegistrationDatetime = Column(DateTime())
 
 
 class User(BaseUser):

--- a/api/views/admin/admin.py
+++ b/api/views/admin/admin.py
@@ -462,8 +462,9 @@ def move_user():
         abort(400, description='username must be specified')
     if sdo_access == '' and vendor_access == '':
         abort(400, description='access-rights-sdo OR access-rights-vendor must be specified')
-    password = db.session.query(TempUser.Password).filter_by(Id=unique_id).first() or ''
-    registration_datetime = db.session.query(TempUser.RegistrationDatetime).filter_by(Id=unique_id).first()
+    password = db.session.query(TempUser.Password).filter_by(Id=unique_id).first().Password or ''
+    registration_datetime = db.session.query(TempUser.RegistrationDatetime) \
+        .filter_by(Id=unique_id).first().RegistrationDatetime
     user = User(Username=username, Password=password, Email=email, ModelsProvider=models_provider,
                 FirstName=name, LastName=last_name, AccessRightsSdo=sdo_access, AccessRightsVendor=vendor_access,
                 RegistrationDatetime=registration_datetime)

--- a/api/views/admin/admin.py
+++ b/api/views/admin/admin.py
@@ -587,7 +587,7 @@ def get_sql_rows(table):
                     'last-name': user.LastName,
                     'access-rights-sdo': user.AccessRightsSdo,
                     'access-rights-vendor': user.AccessRightsVendor,
-                    'registeration-datetime': str(user.RegistrationDatetime)}
+                    'registration-datetime': str(user.RegistrationDatetime)}
         if model == TempUser:
             data_set['motivation'] = user.Motivation
         ret.append(data_set)

--- a/api/views/admin/admin.py
+++ b/api/views/admin/admin.py
@@ -462,9 +462,13 @@ def move_user():
         abort(400, description='username must be specified')
     if sdo_access == '' and vendor_access == '':
         abort(400, description='access-rights-sdo OR access-rights-vendor must be specified')
-    password = db.session.query(TempUser.Password).filter_by(Id=unique_id).first().Password or ''
-    registration_datetime = db.session.query(TempUser.RegistrationDatetime) \
-        .filter_by(Id=unique_id).first().RegistrationDatetime
+    user_password = db.session.query(TempUser.Password).filter_by(Id=unique_id).first()
+    password = user_password.Password if user_password else ''
+    user_registration_datetime = db.session.query(TempUser.RegistrationDatetime).filter_by(Id=unique_id).first()
+    if user_registration_datetime:
+        registration_datetime = user_registration_datetime.RegistrationDatetime
+    else:
+        registration_datetime = datetime.now()
     user = User(Username=username, Password=password, Email=email, ModelsProvider=models_provider,
                 FirstName=name, LastName=last_name, AccessRightsSdo=sdo_access, AccessRightsVendor=vendor_access,
                 RegistrationDatetime=registration_datetime)

--- a/api/views/userSpecificModuleMaintenance/moduleMaintenance.py
+++ b/api/views/userSpecificModuleMaintenance/moduleMaintenance.py
@@ -89,7 +89,7 @@ def register_user():
     except SQLAlchemyError as err:
         app.logger.error('Cannot connect to database. MySQL error: {}'.format(err))
     mf = MessageFactory()
-    mf.send_new_user(username, email)
+    mf.send_new_user(username, email, motivation)
     return ({'info': 'User created successfully'}, 201)
 
 @bp.route('/modules/module/<name>,<revision>,<organization>', methods=['DELETE'])

--- a/api/views/userSpecificModuleMaintenance/moduleMaintenance.py
+++ b/api/views/userSpecificModuleMaintenance/moduleMaintenance.py
@@ -83,7 +83,7 @@ def register_user():
             abort(409, 'User with username {} is pending for permissions'.format(username))
         temp_user = TempUser(Username=username, Password=password, Email=email, ModelsProvider=models_provider,
                              FirstName=name, LastName=last_name, Motivation=motivation,
-                             RegistrationDate=datetime.utcnow())
+                             RegistrationDatetime=datetime.utcnow())
         db.session.add(temp_user)
         db.session.commit()
     except SQLAlchemyError as err:

--- a/api/views/userSpecificModuleMaintenance/moduleMaintenance.py
+++ b/api/views/userSpecificModuleMaintenance/moduleMaintenance.py
@@ -61,7 +61,8 @@ def register_user():
     if not request.json:
         abort(400, description='bad request - no data received')
     body = request.json
-    for data in ['username', 'password', 'password-confirm', 'email', 'company', 'first-name', 'last-name']:
+    for data in ['username', 'password', 'password-confirm', 'email',
+                 'company', 'first-name', 'last-name', 'motivation']:
         if data not in body:
             abort(400, description='bad request - missing {} data in input'.format(data))
     username = body['username']
@@ -72,6 +73,7 @@ def register_user():
     models_provider = body['company']
     name = body['first-name']
     last_name = body['last-name']
+    motivation = body['motivation']
     if password != confirm_password:
         abort(400, 'Passwords do not match')
     try:
@@ -80,7 +82,8 @@ def register_user():
         if db.session.query(TempUser).filter_by(Username=username).all():
             abort(409, 'User with username {} is pending for permissions'.format(username))
         temp_user = TempUser(Username=username, Password=password, Email=email, ModelsProvider=models_provider,
-                             FirstName=name, LastName=last_name)
+                             FirstName=name, LastName=last_name, Motivation=motivation,
+                             RegistrationDate=datetime.utcnow())
         db.session.add(temp_user)
         db.session.commit()
     except SQLAlchemyError as err:

--- a/tests/resources/payloads.json
+++ b/tests/resources/payloads.json
@@ -342,7 +342,8 @@
             "first-name": "test",
             "last-name": "test",
             "email": "test",
-            "password": "test"
+            "password": "test",
+            "motivation": "test"
         }
     }
 }

--- a/utility/messageFactory.py
+++ b/utility/messageFactory.py
@@ -208,10 +208,10 @@ class MessageFactory:
                    'using the schema path:\n{}'.format('\n'.join(modules_list)))
         self.__post_to_email(message, self.__developers_email)
 
-    def send_new_user(self, username: str, email: str):
+    def send_new_user(self, username: str, email: str, motivation: str):
         self.LOGGER.info('Sending notification about new user')
 
         subject = 'Request for access confirmation'
-        msg = 'User {} with email {} is requesting access.\nPlease go to https://yangcatalog.org/admin/mysql-management ' \
-              'and approve or reject this request in Users tab.'.format(username, email)
+        msg = 'User {} with email {} is requesting access.\nMotivation: {}\nPlease go to https://yangcatalog.org/admin/mysql-management ' \
+              'and approve or reject this request in Users tab.'.format(username, email, motivation)
         self.__post_to_email(msg, subject=subject)


### PR DESCRIPTION
The `/api/admin/move-user` and `/api/admin/sql-tables/<table>` endpoints now also check for a `motivation` field. The `/api/admin/sql-tables/<table>` now also returns `motivation` and `registeration-datetime` fields. `/register-user` now expects a `motivation` field.
Before this code is updated, the database should be modified with the following commands:
```sql
ALTER TABLE users
ADD COLUMN RegistrationDatetime TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
ALTER TABLE users_temp
ADD COLUMN Motivation VARCHAR(255)
ADD COLUMN RegistrationDatetime TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
```