### PR TITLE
Run tests only for python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9]
         redis-version: [6]
     environment: tests
 


### PR DESCRIPTION
Our dockerfile specifies python 3.9, so there should be no need to test on python 3.8. Running tests with 2 versions on github actions also causes race conditions for some tests involving external git repositories, which causes them to fail.