### PR TITLE
Compress redis and confd backups

### DIFF
--- a/recovery/redisUsersRecovery.py
+++ b/recovery/redisUsersRecovery.py
@@ -124,7 +124,7 @@ def main(scriptConf=None):
             file_name = '{}.json'.format(os.path.join(backups, args.name_load))
         else:
             list_of_backups = get_list_of_backups(backups)
-            file_name = os.path.join(backups, ''.join(list_of_backups[-1]))
+            file_name = os.path.join(backups, list_of_backups[-1])
 
         with open(file_name) as f:
             data = json.load(f)

--- a/utility/util.py
+++ b/utility/util.py
@@ -489,15 +489,16 @@ def context_check_update_from(old_schema: str, new_schema: str, yang_models: str
     return ctx, new_schema_ctx
 
 
-def get_list_of_backups(directory: str) -> t.List[t.List[str]]:
-    dates = []
+def get_list_of_backups(directory: str) -> t.List[str]:
+    dates: t.List[str] = []
     for name in os.listdir(directory):
         try:
-            split_name = os.path.splitext(name)
-            datetime.datetime.strptime(split_name[0], backup_date_format)
+            i = name.index('.')
+            root = name[:i]
+            datetime.datetime.strptime(root, backup_date_format)
             if os.stat(os.path.join(directory, name)).st_size == 0:
                 continue
-            dates.append(split_name)
+            dates.append(name)
         except ValueError:
             continue
     return sorted(dates)


### PR DESCRIPTION
Resolves #414
Existing backups can be compressed with something like this:
```bash
for backup in /var/yang/cache/confd/*; do gzip $backup; done
for backup in /var/yang/cache/redis/*; do gzip $backup; done
```