### PR TITLE
Fix memory leak while parsing modules

### DIFF
--- a/parseAndPopulate/modules.py
+++ b/parseAndPopulate/modules.py
@@ -220,6 +220,7 @@ class Modules:
             self.__resolve_author_email(author_email)
             self.__resolve_maturity_level(maturity_level)
             self.__resolve_semver()
+        del self.jsons
 
     def __resolve_tree(self):
         if self.module_type == 'module':


### PR DESCRIPTION
Previously, the compilation status data could not
be garbage collected, at it was referenced in each
Modules object and each Modules object was
referenced from the Prepare object. We can let the
garbage collector know we will no longer need this
data after we are done parsing. This allows it to
safely free the memory.