### PR TITLE
Enable files hashing for Openconfig modules

### DIFF
--- a/api/receiver.py
+++ b/api/receiver.py
@@ -105,7 +105,6 @@ class Receiver:
         script_conf.args.__setattr__('sdo', sdo)
         script_conf.args.__setattr__('api', api)
         script_conf.args.__setattr__('dir', direc)
-        script_conf.args.__setattr__('force_parsing', True)
         if self._notify_indexing:
             script_conf.args.__setattr__('notify_indexing', True)
 

--- a/ietfYangDraftPull/openconfigPullLocal.py
+++ b/ietfYangDraftPull/openconfigPullLocal.py
@@ -31,7 +31,6 @@ from glob import glob
 
 import requests
 import utility.log as log
-from parseAndPopulate.fileHasher import FileHasher
 from utility import yangParser
 from utility.create_config import create_config
 from utility.scriptConfig import Arg, BaseScriptConfig
@@ -88,7 +87,6 @@ def main(scriptConf=None):
     log_directory = config.get('Directory-Section', 'logs')
     temp_dir = config.get('Directory-Section', 'temp')
     openconfig_repo_url = config.get('Web-Section', 'openconfig-models-repo-url')
-    cache_dir = config.get('Directory-Section', 'cache')
     LOGGER = log.get_logger('openconfigPullLocal', '{}/jobs/openconfig-pull.log'.format(log_directory))
     LOGGER.info('Starting Cron job openconfig pull request local')
 
@@ -98,8 +96,6 @@ def main(scriptConf=None):
         separator = '/'
         suffix = 'api'
     yangcatalog_api_prefix = '{}://{}{}{}/'.format(api_protocol, api_ip, separator, suffix)
-
-    fileHasher = FileHasher('backend_files_modification_hashes', cache_dir, True, log_directory)
 
     commit_author = {
         'name': config_name,
@@ -113,9 +109,6 @@ def main(scriptConf=None):
             basename = os.path.basename(yang_file)
             name = basename.split('.')[0].split('@')[0]
             revision = resolve_revision(yang_file)
-            should_parse = fileHasher.should_parse_sdo_module(yang_file)
-            if not should_parse:
-                continue
             path = yang_file.split('{}/'.format(repo.localdir))[-1]
             module = {
                 'generated-from': 'not-applicable',

--- a/parseAndPopulate/fileHasher.py
+++ b/parseAndPopulate/fileHasher.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__author__ = "Slavomir Mazur"
-__copyright__ = "Copyright The IETF Trust 2021, All Rights Reserved"
-__license__ = "Apache License, Version 2.0"
-__email__ = "slavomir.mazur@pantheon.tech"
+__author__ = 'Slavomir Mazur'
+__copyright__ = 'Copyright The IETF Trust 2021, All Rights Reserved'
+__license__ = 'Apache License, Version 2.0'
+__email__ = 'slavomir.mazur@pantheon.tech'
 
 import hashlib
 import json
@@ -139,7 +139,7 @@ class FileHasher:
         validators['pyang_version'] = pyang.__version__
         return json.dumps(validators).encode('utf-8')
 
-    def should_parse_sdo_module(self, path: str):
+    def should_parse_sdo_module(self, path: str) -> bool:
         """ Decide whether SDO module at the given path should be parsed or not.
         Check whether file content hash has changed and keep it for the future use.
 
@@ -156,7 +156,7 @@ class FileHasher:
 
         return True if not self.is_active else hash_changed
 
-    def should_parse_vendor_module(self, path: str, platform: str):
+    def should_parse_vendor_module(self, path: str, platform: str) -> bool:
         """ Decide whether vendor module at the given path should be parsed or not.
         Check whether file content hash has changed and keep it for the future use.
 
@@ -174,6 +174,28 @@ class FileHasher:
             if self.updated_hashes.get(path) is None:
                 self.updated_hashes[path] = {}
             self.updated_hashes[path][platform] = file_hash
+            hash_changed = True
+
+        return True if not self.is_active else hash_changed
+
+    def should_parse_openconfig_module(self, path: str) -> bool:
+        """ Decide whether Openconfig module sent via API at the given path should be parsed or not.
+        Check whether file content hash has changed and keep it for the future use.
+
+        Argument:
+            :param path     (str) Full path to the file to be hashed
+            :rtype           bool
+        """
+        hash_changed = False
+
+        path_splitted = path.split('/')
+        del path_splitted[4]  # remove directory set by number from path
+        openconfig_tmp_path = '/'.join(path_splitted)
+
+        file_hash = self.hash_file(path)
+        old_file_hash = self.files_hashes.get(openconfig_tmp_path, None)
+        if old_file_hash is None or old_file_hash != file_hash:
+            self.updated_hashes[openconfig_tmp_path] = file_hash
             hash_changed = True
 
         return True if not self.is_active else hash_changed

--- a/parseAndPopulate/groupings.py
+++ b/parseAndPopulate/groupings.py
@@ -50,7 +50,7 @@ class ModuleGrouping:
             :param dumper               (Dumper) Dumper object
             :param filehasher           (FileHasher) FileHasher object
             :param api                  (bool) whether the request came from API or not
-            :param dir_paths            (dict) paths to various needed directories according to configuration
+            :param dir_paths            (DirPaths) paths to various needed directories according to configuration
         """
 
         global LOGGER
@@ -136,6 +136,11 @@ class SdoDirectory(ModuleGrouping):
             if '[1]' in file_name:
                 LOGGER.warning('File {} contains [1] it its file name'.format(file_name))
                 continue
+            # Openconfig modules are sent via API daily; see openconfigPullLocal.py script
+            if '/openconfig/public/' in path:
+                should_parse = self.file_hasher.should_parse_openconfig_module(path)
+                if not should_parse:
+                    continue
             try:
                 yang = SdoModule(path, self.parsed_jsons, self.dir_paths)
             except ParseException:

--- a/parseAndPopulate/populate.py
+++ b/parseAndPopulate/populate.py
@@ -32,7 +32,6 @@ __email__ = 'miroslav.kovac@pantheon.tech'
 import json
 import multiprocessing
 import os
-import shutil
 import sys
 import time
 import types


### PR DESCRIPTION
- Openconfig modules are sent via API on daily basis
- Modules sent via API do not use files hashing -> Openconfig ones
will be exception, because they were parsed every day

Signed-off-by: Slavomir Mazur <slavomir.mazur@pantheon.tech>