### PR TITLE
Fetch compilation data more efficiently

### DIFF
--- a/parseAndPopulate/loadJsonFiles.py
+++ b/parseAndPopulate/loadJsonFiles.py
@@ -25,26 +25,29 @@ __license__ = "Apache License, Version 2.0"
 __email__ = "miroslav.kovac@pantheon.tech"
 
 import json
+import typing as t
 
 from utility import log
 
 
 class LoadFiles:
 
-    def __init__(self, private_dir: str, log_directory: str):
+    def __init__(self, mangled_name: t.Optional[str], private_dir: str, log_directory: str):
         """
-        Preset LoadFiles class to load all .json files from private directory.
-        Filenames of json files are stored in json_links file.
+        Preset LoadFiles class to load needed .json files from the private directory.
 
+        :param mangled_name
         :param private_dir      (str) path to the directory with private HTML result files
         :param log_directory:   (str) directory where the log file is saved
         """
         LOGGER = log.get_logger(__name__, '{}/parseAndPopulate.log'.format(log_directory))
         LOGGER.debug('Loading compilation statuses and results')
-        excluded_names = ['private', 'IETFCiscoAuthorsYANGPageCompilation']
+        LOGGER.debug('FOOBAR The passed mangled name is {}'.format(mangled_name))
 
-        self.names = self.load_names(private_dir, LOGGER)
-        self.names = [name for name in self.names if name not in excluded_names]
+        self.names = ['IETFDraft', 'IETFDraftExample', 'IETFYANGRFC']
+        if mangled_name:
+            self.names.append(mangled_name)
+        self.mangled_name = mangled_name
         self.status = {}
         self.headers = {}
 
@@ -77,16 +80,3 @@ class LoadFiles:
                     results.append(result)
             self.headers[name] = results
         LOGGER.debug('Compilation statuses and results loaded successfully')
-
-    def load_names(self, private_dir: str, LOGGER):
-        """ Load list of names of json files from json_links file.
-        """
-        names = []
-        try:
-            with open('{}/json_links'.format(private_dir), 'r') as f:
-                for line in f:
-                    names.append(line.replace('.json', '').replace('\n', ''))
-        except FileNotFoundError:
-            LOGGER.exception('json_links file was not found')
-
-        return names

--- a/tests/test_dumper.py
+++ b/tests/test_dumper.py
@@ -205,7 +205,7 @@ class TestDumperClass(unittest.TestCase):
         :returns:           Created instance of Modules object of SDO (ietf) module
         :rtype: Modules
         """
-        parsed_jsons = LoadFiles(self.test_private_dir, yc_gc.logs_dir)
+        parsed_jsons = LoadFiles('IETFTEST', self.test_private_dir, yc_gc.logs_dir)
         path_to_yang = os.path.join(yc_gc.temp_dir, 'test/YangModels/yang/standard/ietf/RFC', self.sdo_module_filename)
 
         yang = SdoModule(self.sdo_module_name, path_to_yang, parsed_jsons, self.dir_paths, 'master', {},
@@ -220,7 +220,7 @@ class TestDumperClass(unittest.TestCase):
         :returns:           Created instance of Modules object of vendor (cisco) module
         :rtype: Modules
         """
-        parsed_jsons = LoadFiles(self.test_private_dir, yc_gc.logs_dir)
+        parsed_jsons = LoadFiles('IETFTEST', self.test_private_dir, yc_gc.logs_dir)
         vendor_data = 'ietf-netconf-acm&revision=2018-02-14&deviations=cisco-xr-ietf-netconf-acm-deviations'
         module_name = vendor_data.split('&revision')[0]
         module_path = '{}/{}.yang'.format(self.resources_path, module_name)

--- a/tests/test_groupings.py
+++ b/tests/test_groupings.py
@@ -117,7 +117,6 @@ class TestGroupingsClass(unittest.TestCase):
         for sdo in sdos_list:
             key = '{}@{}/{}'.format(sdo.get('name'), sdo.get('revision'), sdo.get('organization'))
             self.assertIn(key, sdo_directory.dumper.yang_modules)
-
     @mock.patch('parseAndPopulate.groupings.repoutil.RepoUtil.get_commit_hash')
     def test_sdo_directory_parse_and_load_submodule(self, mock_hash: mock.MagicMock):
         """
@@ -135,7 +134,8 @@ class TestGroupingsClass(unittest.TestCase):
 
         sdo_directory = SdoDirectory(path, dumper, self.fileHasher, api, self.dir_paths)
 
-        sdo_directory.parse_and_load(repo)
+        with mock.patch.object(sdo_directory, '_construct_json_name', lambda x, y: 'IETFTEST'):
+            sdo_directory.parse_and_load(repo)
         sdo_directory.dumper.dump_modules(yc_gc.temp_dir)
 
         desired_module_data = self.load_desired_prepare_json_data('git_submodule_huawei')
@@ -342,7 +342,7 @@ class TestGroupingsClass(unittest.TestCase):
         :returns:               Created instance of Modules object of SDO (ietf) module
         :rtype: Modules
         """
-        parsed_jsons = LoadFiles(self.test_private_dir, yc_gc.logs_dir)
+        parsed_jsons = LoadFiles('IETFYANGRFC', self.test_private_dir, yc_gc.logs_dir)
         module_name = path_to_yang.split('/')[-1].split('.yang')[0]
         schema_base = os.path.join(github_raw, 'YangModels/yang/master')
         if '@' in module_name:

--- a/tests/test_loadJsonFiles.py
+++ b/tests/test_loadJsonFiles.py
@@ -29,7 +29,6 @@ class TestLoadFilesClass(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(TestLoadFilesClass, self).__init__(*args, **kwargs)
-        self.excluded_names = ['private', 'IETFCiscoAuthorsYANGPageCompilation']
         self.test_private_dir = os.path.join(os.environ['BACKEND'], 'tests/resources/html/private')
 
     def test_loadJsonFiles(self):
@@ -37,13 +36,9 @@ class TestLoadFilesClass(unittest.TestCase):
         Test if 'parsed_jsons' object has the individual attributes set correctly.
         Excluded file names should no be present in 'parsed_json' dict as keys.
         """
-        parsed_jsons = LoadFiles(self.test_private_dir, yc_gc.logs_dir)
+        parsed_jsons = LoadFiles('IETFYANGRFC', self.test_private_dir, yc_gc.logs_dir)
 
-        names = []
-        with open('{}/json_links'.format(self.test_private_dir), 'r') as f:
-            for line in f:
-                names.append(line.replace('.json', '').replace('\n', ''))
-        names = [name for name in names if name not in self.excluded_names]
+        names = ['IETFDraft', 'IETFDraftExample', 'IETFYANGRFC', 'IETFYANGRFC']
 
         # Object should containt following attributes
         self.assertTrue(hasattr(parsed_jsons, 'headers'))
@@ -57,43 +52,17 @@ class TestLoadFilesClass(unittest.TestCase):
             self.assertIn(name, parsed_jsons.headers)
             self.assertIn(name, parsed_jsons.status)
 
-        # Property should NOT be set for excluded names
-        for name in self.excluded_names:
-            self.assertNotIn(name, parsed_jsons.headers)
-            self.assertNotIn(name, parsed_jsons.status)
 
-    def test_loadJsonFiles_json_links_not_found(self):
+    def test_loadJsonFiles_non_existing_json_file(self):
         """
         Test if 'parsed_jsons' object has the individual attributes set correctly.
-        Incorrect path is passed as argument resulting no json_link file is found there.
-        All attributes should be empty as the file was not found.
-        """
-        parsed_jsons = LoadFiles('path/to/random/dir', yc_gc.logs_dir)
-
-        # Object should containt following attributes
-        self.assertTrue(hasattr(parsed_jsons, 'headers'))
-        self.assertTrue(hasattr(parsed_jsons, 'names'))
-        self.assertTrue(hasattr(parsed_jsons, 'status'))
-
-        # Attributes should be empty as the file was not found
-        self.assertEqual(parsed_jsons.names, [])
-        self.assertEqual(parsed_jsons.headers, {})
-        self.assertEqual(parsed_jsons.status, {})
-
-    @mock.patch('parseAndPopulate.loadJsonFiles.LoadFiles.load_names')
-    def test_loadJsonFiles_non_existing_json_file(self, mock_load_names: mock.MagicMock):
-        """
-        Test if 'parsed_jsons' object has the individual attributes set correctly.
-        load_names() method will return non-exisiting name of json file, so FileNotFound exceptions will be raised
-        while trying to load content of json/html files - headers and status properties should be empty for this name.
+        FileNotFound exceptions will be raised while trying to load content of json/html files
+        - headers and status properties should be empty for this name.
 
         Arguments:
         :param mock_load_names  (mock.MagicMock) load_names() method is patched, to return name of non-exisiting json
         """
-        non_existing_json_name = 'SuperRandom'
-        mock_load_names.return_value = [non_existing_json_name]
-
-        parsed_jsons = LoadFiles(self.test_private_dir, yc_gc.logs_dir)
+        parsed_jsons = LoadFiles('SuperRandom', self.test_private_dir, yc_gc.logs_dir)
 
         # Object should containt following attributes
         self.assertTrue(hasattr(parsed_jsons, 'headers'))
@@ -101,9 +70,10 @@ class TestLoadFilesClass(unittest.TestCase):
         self.assertTrue(hasattr(parsed_jsons, 'status'))
 
         # Status and headers should be empty for non-existing json/html files
-        self.assertEqual(parsed_jsons.headers[non_existing_json_name], [])
-        self.assertEqual(parsed_jsons.status[non_existing_json_name], {})
+        print(parsed_jsons.headers)
+        self.assertEqual(parsed_jsons.headers['SuperRandom'], [])
+        self.assertEqual(parsed_jsons.status['SuperRandom'], {})
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -41,7 +41,6 @@ class TestModulesClass(unittest.TestCase):
         self.hello_message_filename = 'capabilities-ncs5k.xml'
         self.resources_path = os.path.join(os.environ['BACKEND'], 'tests/resources')
         self.test_private_dir = os.path.join(self.resources_path, 'html/private')
-        self.parsed_jsons = LoadFiles(self.test_private_dir, yc_gc.logs_dir)
         self.dir_paths: DirPaths = {
             'cache': '',
             'json': '',
@@ -65,7 +64,8 @@ class TestModulesClass(unittest.TestCase):
         """
         path_to_yang = os.path.join(yc_gc.save_file_dir, self.sdo_module_filename)
 
-        yang = SdoModule(self.sdo_module_name, path_to_yang, self.parsed_jsons, self.dir_paths, 'master', {},
+        parsed_jsons = LoadFiles('IETFYANGRFC', self.test_private_dir, yc_gc.logs_dir)
+        yang = SdoModule(self.sdo_module_name, path_to_yang, parsed_jsons, self.dir_paths, 'master', {},
                          self.schema_base)
 
         self.assertEqual(yang.document_name, 'rfc6991')
@@ -98,7 +98,8 @@ class TestModulesClass(unittest.TestCase):
             'module-classification': 'testing'
         }
 
-        yang = SdoModule(self.sdo_module_name, path_to_yang, self.parsed_jsons, self.dir_paths, 'master', keys,
+        parsed_jsons = LoadFiles('IETFYANGRFC', self.test_private_dir, yc_gc.logs_dir)
+        yang = SdoModule(self.sdo_module_name, path_to_yang, parsed_jsons, self.dir_paths, 'master', keys,
                          self.schema_base, additional_info)
 
         self.assertEqual(yang.name, 'ietf-yang-types')
@@ -117,7 +118,8 @@ class TestModulesClass(unittest.TestCase):
         path_to_yang = '{}/vendor/cisco/xr/701/{}.yang'.format(self.test_repo, module_name)
         deviation = yang_lib_data.split('&deviations=')[1]
 
-        yang = VendorModule(module_name, path_to_yang, self.parsed_jsons, self.dir_paths, 'master', {}, '',
+        parsed_jsons = LoadFiles('CiscoXR701', self.test_private_dir, yc_gc.logs_dir)
+        yang = VendorModule(module_name, path_to_yang, parsed_jsons, self.dir_paths, 'master', {}, '',
                             data=yang_lib_data)
 
         self.assertEqual(yang.document_name, 'rfc8341')
@@ -146,7 +148,8 @@ class TestModulesClass(unittest.TestCase):
 
         platform_data, netconf_versions, netconf_capabilities = self.get_platform_data(xml_path, platform_name)
 
-        yang = VendorModule(module_name, path_to_yang, self.parsed_jsons, self.dir_paths, 'master', {}, '',
+        parsed_jsons = LoadFiles('CiscoXR701', self.test_private_dir, yc_gc.logs_dir)
+        yang = VendorModule(module_name, path_to_yang, parsed_jsons, self.dir_paths, 'master', {}, '',
                             data=vendor_data)
         yang.add_vendor_information(platform_data, 'implement', netconf_capabilities, netconf_versions)
 
@@ -184,7 +187,8 @@ class TestModulesClass(unittest.TestCase):
 
         platform_data, netconf_versions, netconf_capabilities = self.get_platform_data(xml_path, platform_name)
 
-        yang = VendorModule(module_name, path_to_yang, self.parsed_jsons, self.dir_paths, 'master', {}, schema_part,
+        parsed_jsons = LoadFiles('NETWORKROUTER8200', self.test_private_dir, yc_gc.logs_dir)
+        yang = VendorModule(module_name, path_to_yang, parsed_jsons, self.dir_paths, 'master', {}, schema_part,
                             data=yang_lib_info)
 
         yang.add_vendor_information(platform_data, 'implement', netconf_capabilities, netconf_versions)

--- a/tests/test_receiver.py
+++ b/tests/test_receiver.py
@@ -163,7 +163,7 @@ class TestReceiverClass(TestReceiverBaseClass):
     @ mock.patch('parseAndPopulate.groupings.LoadFiles')
     @ mock.patch('parseAndPopulate.populate.reload_cache_in_parallel', MockRepoUtil)
     def test_process_sdo(self, mock_load_files: mock.MagicMock):
-        mock_load_files.return_value = LoadFiles(self.private_dir, self.log_directory)
+        mock_load_files.return_value = LoadFiles('IETFYANGRFC', self.private_dir, self.log_directory)
         data = self.test_data.get('request-data-content')
         dst = '{}/YangModels/yang/standard/ietf/RFC'.format(self.direc)
         os.makedirs(dst, exist_ok=True)
@@ -205,7 +205,7 @@ class TestReceiverClass(TestReceiverBaseClass):
     @ mock.patch('parseAndPopulate.groupings.LoadFiles')
     @ mock.patch('parseAndPopulate.populate.reload_cache_in_parallel', MockRepoUtil)
     def test_process_vendor(self, mock_load_files: mock.MagicMock):
-        mock_load_files.return_value = LoadFiles(self.private_dir, self.log_directory)
+        mock_load_files.return_value = LoadFiles('IETFYANGRFC', self.private_dir, self.log_directory)
         platform = self.test_data.get('capabilities-json-content')
 
         dst = '{}/huawei/yang/network-router/8.20.0/ne5000e'.format(self.direc)

--- a/tests/test_runCapabilities.py
+++ b/tests/test_runCapabilities.py
@@ -51,7 +51,7 @@ class TestRunCapabilitiesClass(unittest.TestCase):
         :param mock_load_files  (mock.MagicMock) LoadFiles is patched to load json files from test directory
         """
         mock_hash.return_value = 'master'
-        mock_load_files.return_value = LoadFiles(self.test_private_dir, yc_gc.logs_dir)
+        mock_load_files.return_value = LoadFiles('IETFTEST', self.test_private_dir, yc_gc.logs_dir)
         path = '{}/test/YangModels/yang/standard/ietf/RFC'.format(yc_gc.temp_dir)
         # Load submodule and its config
         module = __import__(self.module_name, fromlist=[self.script_name])
@@ -99,7 +99,7 @@ class TestRunCapabilitiesClass(unittest.TestCase):
         :param mock_load_files  (mock.MagicMock) LoadFiles is patched to load json files from test directory
         """
         mock_hash.return_value = 'master'
-        mock_load_files.return_value = LoadFiles(self.test_private_dir, yc_gc.logs_dir)
+        mock_load_files.return_value = LoadFiles('IETFYANGRFC', self.test_private_dir, yc_gc.logs_dir)
         path = '{}/temp/standard/ietf/RFC/empty'.format(yc_gc.temp_dir)
         # Load submodule and its config
         module = __import__(self.module_name, fromlist=[self.script_name])
@@ -129,7 +129,7 @@ class TestRunCapabilitiesClass(unittest.TestCase):
         :param mock_load_files  (mock.MagicMock) LoadFiles is patched to load json files from test directory
         """
         mock_commit_hash.return_value = 'master'
-        mock_load_files.return_value = LoadFiles(self.test_private_dir, yc_gc.logs_dir)
+        mock_load_files.return_value = LoadFiles('IETFYANGRFC', self.test_private_dir, yc_gc.logs_dir)
         xml_path = '{}/test/YangModels/yang/vendor/cisco/xr/701'.format(yc_gc.temp_dir)
         # Load submodule and its config
         module = __import__(self.module_name, fromlist=[self.script_name])
@@ -220,7 +220,7 @@ class TestRunCapabilitiesClass(unittest.TestCase):
         :param mock_hash        (mock.MagicMock) get_commit_hash() method is patched, to always return 'master'
         :param mock_load_files  (mock.MagicMock) LoadFiles is patched to load json files from test directory
         """
-        mock_load_files.return_value = LoadFiles(self.test_private_dir, yc_gc.logs_dir)
+        mock_load_files.return_value = LoadFiles('IETFTEST', self.test_private_dir, yc_gc.logs_dir)
         mock_hash.return_value = 'master'
         xml_path = '{}/test/YangModels/yang/vendor/huawei/network-router/8.20.0/ne5000e'.format(yc_gc.temp_dir)
         # Load submodule and its config


### PR DESCRIPTION
Instead of searching over all jsons containing compilation
results, construct the name of the json file we're interested in
and load only that into memory.

It's difficult to measure the decrease in RAM usage properly,
but I have some figures to give an idea:
An idle backend container consumes about 370MB.
With the command
`python populate.py --dir /var/yang/nonietf/yangmodels/yang/vendor/fujitsu/`
old: >2GB in a couple seconds and crashes due to exhausting RAM
new: ~460MB
