### PR TITLE
Some performance fix suggestion for parse directory script

### DIFF
--- a/parseAndPopulate/parse_directory.py
+++ b/parseAndPopulate/parse_directory.py
@@ -206,7 +206,7 @@ def parse_vendor(search_directory: str, dumper: Dumper, file_hasher: FileHasher,
             try:
                 grouping.parse_and_load()
             except Exception:
-                logger.exception('Skipping {}, error while parsing'.format(filename))
+                logger.exception('Skipping {}, error while parsing'.format(path))
 
 
 if __name__ == '__main__':

--- a/parseAndPopulate/populate.py
+++ b/parseAndPopulate/populate.py
@@ -88,7 +88,7 @@ class ScriptConfig(BaseScriptConfig):
                 'flag': '--sdo',
                 'help': 'If we are processing sdo or vendor yang modules',
                 'action': 'store_true',
-                'default': False
+                'default': True
             },
             {
                 'flag': '--notify-indexing',


### PR DESCRIPTION
I spotted that the parse_vendor() function has nested loops, this function loops over all the files in search_directory two times (one time for every pattern), so I rewrote that functionality using only one loop. It's also important that find_files() is a generator, so if the use of the generator and nested loop is made on purpose, this pull request should be closed.