### PR TITLE
chore: revise parseAndPopulate exception handling and logging

### DIFF
--- a/parseAndPopulate/groupings.py
+++ b/parseAndPopulate/groupings.py
@@ -81,6 +81,8 @@ class ModuleGrouping:
                 self._schemas = json.load(f)
         except (FileNotFoundError, json.JSONDecodeError):
             self._schemas = {}
+        self.parsed = 0
+        self.skipped = 0
 
     def _dump_schema_cache(self):
         try:
@@ -178,7 +180,7 @@ class SdoDirectory(ModuleGrouping):
         self.path_to_name_rev = path_to_name_rev
         super().__init__(directory, dumper, file_hasher, api, dir_paths, config=config)
 
-    def parse_and_load(self, repo: t.Optional[repoutil.RepoUtil] = None):
+    def parse_and_load(self, repo: t.Optional[repoutil.RepoUtil] = None) -> tuple[int, int]:
         """
         If modules were sent via the API, the contents of the request-data.json file are parsed
         and modules are loaded from Git repository.
@@ -188,12 +190,13 @@ class SdoDirectory(ModuleGrouping):
             :param repo     Git repository which contains .yang files
         """
         if self.api:
-            self._parse_and_load_api()
+            ret = self._parse_and_load_api()
         else:
-            self._parse_and_load_not_api()
+            ret = self._parse_and_load_not_api()
         self._dump_schema_cache()
+        return ret
 
-    def _parse_and_load_api(self):
+    def _parse_and_load_api(self) -> tuple[int, int]:
         self.logger.debug('Parsing sdo files sent via API')
         with open(os.path.join(self.dir_paths['json'], 'request-data.json'), 'r') as f:
             sdos_json = json.load(f)
@@ -229,6 +232,7 @@ class SdoDirectory(ModuleGrouping):
                     continue
                 should_parse = self.file_hasher.should_parse_sdo_module(all_modules_path)
                 if not should_parse:
+                    self.skipped += 1
                     continue
             schema_parts = SchemaParts(repo_owner=self.repo_owner, repo_name=self.repo_name, commit_hash=commit_hash)
             self._update_schema_urls(name, revision, path, schema_parts)
@@ -246,8 +250,10 @@ class SdoDirectory(ModuleGrouping):
                 self.log_module_creation_exception(e)
                 continue
             self.dumper.add_module(yang)
+            self.parsed += 1
+        return self.parsed, self.skipped
 
-    def _parse_and_load_not_api(self):
+    def _parse_and_load_not_api(self) -> tuple[int, int]:
         self.logger.debug('Parsing sdo files from directory')
         self._load_yangmodels_repo()
         # Check if repository submodule
@@ -275,6 +281,7 @@ class SdoDirectory(ModuleGrouping):
                     continue
                 should_parse = self.file_hasher.should_parse_sdo_module(all_modules_path)
                 if not should_parse:
+                    self.skipped += 1
                     continue
                 if '[1]' in file_name:
                     self.logger.warning(f'File {file_name} contains [1] it its file name')
@@ -294,6 +301,8 @@ class SdoDirectory(ModuleGrouping):
                     self.log_module_creation_exception(e)
                     continue
                 self.dumper.add_module(yang)
+                self.parsed += 1
+        return self.parsed, self.skipped
 
 
 class IanaDirectory(SdoDirectory):
@@ -320,7 +329,7 @@ class IanaDirectory(SdoDirectory):
             self.iana_skip = []
         self.root = ET.parse(os.path.join(directory, 'yang-parameters.xml')).getroot()
 
-    def parse_and_load(self, **kwargs):
+    def parse_and_load(self, **kwargs) -> tuple[int, int]:
         """Parse all IANA-maintained modules listed in the yang-parameters.xml file."""
         tag = self.root.tag
         namespace = tag.split('registry')[0]
@@ -366,6 +375,7 @@ class IanaDirectory(SdoDirectory):
                     continue
                 should_parse = self.file_hasher.should_parse_sdo_module(all_modules_path)
                 if not should_parse:
+                    self.skipped += 1
                     continue
 
                 self.logger.info(f'Parsing module {name}')
@@ -384,7 +394,9 @@ class IanaDirectory(SdoDirectory):
                     self.log_module_creation_exception(e)
                     continue
                 self.dumper.add_module(yang)
+                self.parsed += 1
         self._dump_schema_cache()
+        return self.parsed, self.skipped
 
 
 class VendorGrouping(ModuleGrouping):
@@ -544,6 +556,7 @@ class VendorGrouping(ModuleGrouping):
                 return
             module_hash_info = self.file_hasher.check_vendor_module_hash_for_parsing(path, self.implementation_keys)
             if not module_hash_info.module_should_be_parsed:
+                self.skipped += 1
                 continue
             revision = path.split('@')[-1].removesuffix('.yang')
             if (name, revision) in self.name_rev_to_path:
@@ -571,6 +584,7 @@ class VendorGrouping(ModuleGrouping):
                 self.log_module_creation_exception(e)
                 continue
             self.dumper.add_module(yang)
+            self.parsed += 1
             key = f'{yang.name}@{yang.revision}/{yang.organization}'
             set_of_names.add(yang.name)
             self._parse_imp_inc(self.dumper.yang_modules[key].submodule, set_of_names, True, schema_parts)
@@ -580,7 +594,7 @@ class VendorGrouping(ModuleGrouping):
 class VendorCapabilities(VendorGrouping):
     """Modules listed in a capabilities xml file."""
 
-    def parse_and_load(self):
+    def parse_and_load(self) -> tuple[int, int]:
         """
         Parse and load all information from the capabilities xml file and
         implementation data from a platform-metadata json file if present.
@@ -635,6 +649,7 @@ class VendorCapabilities(VendorGrouping):
                 continue
             module_hash_info = self.file_hasher.check_vendor_module_hash_for_parsing(path, self.implementation_keys)
             if not module_hash_info.module_should_be_parsed:
+                self.skipped += 1
                 continue
             self.logger.info(f'Parsing module {name}')
             revision = revision or path.split('@')[-1].removesuffix('.yang')
@@ -664,6 +679,7 @@ class VendorCapabilities(VendorGrouping):
                 self.log_module_creation_exception(e)
                 continue
             self.dumper.add_module(yang)
+            self.parsed += 1
             key = f'{yang.name}@{yang.revision}/{yang.organization}'
             keys.add(key)
             set_of_names.add(yang.name)
@@ -672,10 +688,11 @@ class VendorCapabilities(VendorGrouping):
             self._parse_imp_inc(self.dumper.yang_modules[key].submodule, set_of_names, True, schema_parts)
             self._parse_imp_inc(self.dumper.yang_modules[key].imports, set_of_names, False, schema_parts)
         self._dump_schema_cache()
+        return self.parsed, self.skipped
 
 
 class VendorYangLibrary(VendorGrouping):
-    def parse_and_load(self):
+    def parse_and_load(self) -> tuple[int, int]:
         """Load implementation information which are stored platform-metadata.json file.
         Set this implementation information for each module parsed out from ietf-yang-library xml file.
         """
@@ -723,6 +740,7 @@ class VendorYangLibrary(VendorGrouping):
                 continue
             module_hash_info = self.file_hasher.check_vendor_module_hash_for_parsing(path, self.implementation_keys)
             if not module_hash_info.module_should_be_parsed:
+                self.skipped += 1
                 continue
             revision = revision or path.split('@')[-1].removesuffix('.yang')
             if (name, revision) in self.name_rev_to_path:
@@ -751,6 +769,7 @@ class VendorYangLibrary(VendorGrouping):
                 self.log_module_creation_exception(e)
                 continue
             self.dumper.add_module(yang)
+            self.parsed += 1
             keys.add(f'{yang.name}@{yang.revision}/{yang.organization}')
             set_of_names.add(yang.name)
 
@@ -758,3 +777,4 @@ class VendorYangLibrary(VendorGrouping):
             self._parse_imp_inc(self.dumper.yang_modules[key].submodule, set_of_names, True, schema_parts)
             self._parse_imp_inc(self.dumper.yang_modules[key].imports, set_of_names, False, schema_parts)
         self._dump_schema_cache()
+        return self.parsed, self.skipped

--- a/parseAndPopulate/modules.py
+++ b/parseAndPopulate/modules.py
@@ -99,19 +99,9 @@ class Module:
             redis_connection if redis_connection or not can_be_already_stored_in_db else RedisConnection(config=config)
         )
 
-        self._parse_yang()
+        self._parsed_yang = yangParser.parse(self._path)
         self.implementations: list[Implementation] = []
         self._parse_all(name, yang_modules, additional_info)
-
-    def _parse_yang(self):
-        try:
-            self._parsed_yang = yangParser.parse(self._path)
-        except yangParser.ParseException:
-            if not os.path.isfile(self._path):
-                self.logger.error(f'Missing yang file {self._path}')
-            else:
-                self.logger.warning(f'pyang error on {self._path}')
-            raise
 
     def _parse_all(self, name: str, yang_modules: dict, additional_info: t.Optional[dict[str, str]]):
         additional_info = additional_info or {}

--- a/utility/yangParser.py
+++ b/utility/yangParser.py
@@ -28,7 +28,6 @@ from pyang.context import Context
 from pyang.error import error_codes
 from pyang.repository import FileRepository
 from pyang.statements import Statement
-from pyang.yang_parser import YangParser
 
 from utility.create_config import create_config
 
@@ -188,45 +187,23 @@ class ParseException(Exception):
                 json.dump(modules, f)
 
 
-def parse(text: str) -> Statement:
-    """Parse a YANG statement into an Abstract Syntax subtree.
+def parse(path: str) -> Statement:
+    """
+    Parse a YANG statement into an Abstract Syntax subtree.
 
     Arguments:
-        text (str): file name for a YANG module or text
-
-    Returns:
-        pyang.statements.Statement: Abstract syntax subtree
-
-    Note:
-        The ``parse`` function can be used to parse small amounts of text.
-        If yout plan to parse an entire YANG (sub)module, please use instead::
-
-            ast = ctx.add_module(module_name, text_contet)
-
-        It is also well known that ``parse`` function cannot solve
-        YANG deviations yet.
-    Note II:
-        pyang.Context removed as optional parameter as it was not used anymore.
+        path    (str) Path to a YANG module
+        return  (pyang.statements.Statement) Abstract syntax subtree
     """
-    parser = YangParser()  # Similar names, but, this one is from PYANG library
+    if not isfile(path):
+        raise FileNotFoundError(path)
 
-    filename = 'parser-input'
+    ctx = create_context()
+    ctx.errors = []
 
-    ctx_ = create_context()
-
-    if isfile(text):
-        filename = text
-        with open(filename) as f:
-            text = f.read()
-
-    # ensure reported errors are just from parsing
-    # old_errors = ctx_.errors
-    ctx_.errors = []
-
-    ast = parser.parse(ctx_, filename, text)
+    with open(path) as f:
+        ast = ctx.add_module(path, f.read())
     if ast is None:
-        raise ParseException(filename if filename != 'parser-input' else None)
-
-    ctx_.internal_reset()
+        raise ParseException(path)
 
     return ast


### PR DESCRIPTION
Let `ModuleGrouping`s handle module parse errors.
Do not log an error when all modules have already been cached.