### PR TITLE
feat: remove uuid directories from /var/yang/tmp in remove_unused.py script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -123,10 +123,10 @@
       "justMyCode": false
     },
     {
-      "name": "removeUnused",
+      "name": "remove_unused",
       "type": "python",
       "request": "launch",
-      "program": "${workspaceFolder}/utility/removeUnused.py",
+      "program": "${workspaceFolder}/utility/remove_unused.py",
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "justMyCode": false

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ information about what vendors' and SDOs' modules we have and the number of
 modules that we have.
 * [resolveExpiration](https://github.com/YangCatalog/backend/blob/master/utility/resolveExpiration.py) job that checks all the IETF draft modules
 and their expiration dates and updates its metadata accordingly.
-* [removeUnused](https://github.com/YangCatalog/backend/blob/master/utility/removeUnused.py) job that removes data on the server that are not used
+* [remove_unused](https://github.com/YangCatalog/backend/blob/master/utility/remove_unused.py) job that removes data on the server that are not used
 anymore.
 * [userReminder](https://github.com/YangCatalog/backend/blob/master/utility/userReminder.py) script that will be triggered twice a year to show us what
 users we have in our database.

--- a/crontab
+++ b/crontab
@@ -20,7 +20,7 @@ BACKEND=/backend
 5 18 * * * (cd ~ ; source bin/activate ; echo "`date` starting draftPull" >> /var/yang/logs/crons-log.log ; cd ietfYangDraftPull ; python draftPull.py --send-message)
 5 22 * * * (cd ~ ; source bin/activate ; echo "`date` starting draftPullLocal" >> /var/yang/logs/crons-log.log ; cd ietfYangDraftPull ; python draftPullLocal.py )
 17 18 * * * (cd ~ ; source bin/activate ; echo "`date` starting recovery" >> /var/yang/logs/crons-log.log ; cd  recovery ; python recovery.py --save)
-30 15 * * * (cd ~ ; source bin/activate ; echo "`date` starting removeUnused" >> /var/yang/logs/crons-log.log ; cd  utility ; python removeUnused.py)
+30 15 * * * (cd ~ ; source bin/activate ; echo "`date` starting remove_unused" >> /var/yang/logs/crons-log.log ; cd  utility ; python remove_unused.py)
 */3 * * * * (cd ~ ; source bin/activate ; cd  elasticsearchIndexing ; python process_changed_mods.py)
 0 2 */1 * * (cd ~ ; source bin/activate ; cd elasticsearchIndexing ; python process-drafts.py)
 0 */2 * * * (cd ~ ; source bin/activate ; cd utility ; python confdFullCheck.py)

--- a/documentation/source/index.html.md
+++ b/documentation/source/index.html.md
@@ -3153,7 +3153,7 @@ curl -X GET -H "Accept: application/json" -H "Content-type: application/json"
       "start": 1599589021,
       "status": "Success"
     },
-    "removeUnused": {
+    "remove_unused": {
       "end": 1599579002,
       "error": "AuthenticationException(401, '{\"Message\":\"settings.role_arn is needed for snapshot registration.\"}')",
       "start": 1599579002,

--- a/parseAndPopulate/populate.py
+++ b/parseAndPopulate/populate.py
@@ -32,6 +32,7 @@ __email__ = 'miroslav.kovac@pantheon.tech'
 import json
 import multiprocessing
 import os
+import shutil
 import sys
 import time
 import typing as t
@@ -200,6 +201,11 @@ class Populate:
             # Keep new hashes only if the ConfD was patched successfully
             if not self.errors:
                 self._update_files_hashes()
+        try:
+            uuid.UUID(self.json_dir)
+            shutil.rmtree(self.json_dir)
+        except ValueError:
+            pass
         self.logger.info('Populate script finished successfully')
 
     def _send_notification_about_running_script_by_api(self):


### PR DESCRIPTION
Renamed the ```removeUnused.py``` script to ```remove_unused.py``` and added removing of UUID-like directories from the ```/var/yang/temp``` directory in this script. I also added removing the temp JSON dir in the ```populate.py``` script.

resolves #667 