### PR TITLE
refactor: execute ES query without scroll

### DIFF
--- a/api/views/yangSearch/elkSearch.py
+++ b/api/views/yangSearch/elkSearch.py
@@ -200,7 +200,7 @@ class ElkSearch:
             if module_key in reject:
                 continue
 
-            module_latest_revision = self._latest_revisions.get(row.module_name, '').replace('02-28', '02-29')
+            module_latest_revision = self._latest_revisions.get(row.module_name, '').replace('02-29', '02-28')
             if self._search_params.latest_revision and row.revision != module_latest_revision:
                 reject.append(module_key)
                 continue

--- a/api/views/yangSearch/response_row.py
+++ b/api/views/yangSearch/response_row.py
@@ -27,7 +27,7 @@ from utility.staticVariables import OUTPUT_COLUMNS, SDOS
 class ResponseRow:
     def __init__(self, elastic_hit: dict) -> None:
         self.name = elastic_hit['argument']
-        self.revision = elastic_hit['revision'].replace('02-28', '02-29')
+        self.revision = elastic_hit['revision'].replace('02-29', '02-28')
         self.schema_type = elastic_hit['statement']
         self.path = elastic_hit['path']
         self.module_name = elastic_hit['module']


### PR DESCRIPTION
ES scroll functionality was being used incorrectly.
Removed use of the scroll api. Removed separate ES query for aggregations.