### PR TITLE
feat: improved the grep search

### DIFF
--- a/elasticsearchIndexing/json/initialize_test_search_index.json
+++ b/elasticsearchIndexing/json/initialize_test_search_index.json
@@ -28,7 +28,7 @@
   },
   "mappings": {
     "properties": {
-      "module": {
+      "name": {
         "type": "text",
         "analyzer": "edge_ngram_analyzer",
         "fields": {
@@ -47,43 +47,6 @@
             "ignore_above": 256
           }
         }
-      },
-      "argument": {
-        "type": "text",
-        "fields": {
-          "sensitive": {
-            "type": "text",
-            "analyzer": "edge_ngram_analyzer"
-          },
-          "lowercase": {
-            "type": "text",
-            "analyzer": "edge_ngram_analyzer"
-          },
-          "keyword": {
-            "type": "keyword",
-            "ignore_above": 256
-          }
-        }
-      },
-      "description": {
-        "type": "text",
-        "fields": {
-          "sensitive": {
-            "type": "text",
-            "analyzer": "edge_ngram_analyzer"
-          },
-          "lowercase": {
-            "type": "text",
-            "analyzer": "edge_ngram_analyzer"
-          },
-          "keyword": {
-            "type": "keyword",
-            "ignore_above": 256
-          }
-        }
-      },
-      "sdo": {
-        "type": "boolean"
       },
       "revision": {
         "type": "date"

--- a/tests/resources/test_search/search_test_data.json
+++ b/tests/resources/test_search/search_test_data.json
@@ -1,139 +1,79 @@
 {
   "all_modules": [
     {
-      "module": "cisco-xr-ietf-netconf-acm-deviations",
+      "name": "cisco-xr-ietf-netconf-acm-deviations",
       "revision": "2017-08-02",
-      "organization": "cisco",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "cisco"
     },
     {
-      "module": "fujitsu-database",
+      "name": "fujitsu-database",
       "revision": "2017-11-13",
-      "organization": "fujitsu",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "fujitsu"
     },
     {
-      "module": "fujitsu-ip",
+      "name": "fujitsu-ip",
       "revision": "2018-04-17",
-      "organization": "fujitsu",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "fujitsu"
     },
     {
-      "module": "ietf-inet-types",
+      "name": "ietf-inet-types",
       "revision": "2020-07-06",
-      "organization": "ietf",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "ietf"
     },
     {
-      "module": "openconfig-telemetry",
+      "name": "openconfig-telemetry",
       "revision": "2018-11-21",
-      "organization": "openconfig",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "openconfig"
     },
     {
-      "module": "sdo-module",
+      "name": "sdo-module",
       "revision": "2022-08-05",
-      "organization": "ietf",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "ietf"
     },
     {
-      "module": "semver-test",
+      "name": "semver-test",
       "revision": "2020-01-01",
-      "organization": "ietf",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "ietf"
     },
     {
-      "module": "semver-test",
+      "name": "semver-test",
       "revision": "2020-02-01",
-      "organization": "ietf",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "ietf"
     },
     {
-      "module": "semver-test",
+      "name": "semver-test",
       "revision": "2020-03-01",
-      "organization": "ietf",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "ietf"
     },
     {
-      "module": "semver-test",
+      "name": "semver-test",
       "revision": "2020-04-01",
-      "organization": "ietf",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "ietf"
     },
     {
-      "module": "semver-test",
+      "name": "semver-test",
       "revision": "2020-05-01",
-      "organization": "ietf",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "ietf"
     },
     {
-      "module": "semver-test",
+      "name": "semver-test",
       "revision": "2020-06-01",
-      "organization": "ietf",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "ietf"
     },
     {
-      "module": "vendor-module",
+      "name": "vendor-module",
       "revision": "2022-08-05",
-      "organization": "cisco",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "cisco"
     },
     {
-      "module": "yang-catalog",
+      "name": "yang-catalog",
       "revision": "2017-09-26",
-      "organization": "ietf",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "ietf"
     },
     {
-      "module": "yang-catalog",
+      "name": "yang-catalog",
       "revision": "2018-04-03",
-      "organization": "ietf",
-      "argument": "test argument",
-      "statement": "test statement",
-      "path": "path",
-      "description": "description"
+      "organization": "ietf"
     }
   ]
 }

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,11 +13,6 @@ from elasticsearchIndexing.models.es_indices import ESIndices
 from utility.create_config import create_config
 
 
-class RedisConnectionMock:
-    def get_module(self, module_key: str):
-        return b'{}'
-
-
 class TestGrepSearchClass(unittest.TestCase):
     resources_path: str
     es: Elasticsearch
@@ -29,7 +24,6 @@ class TestGrepSearchClass(unittest.TestCase):
         cls.config = create_config()
         cls.resources_path = os.path.join(os.environ['BACKEND'], 'tests', 'resources')
         cls._configure_es(cls.config)
-        cls.redis_connection_mock = RedisConnectionMock()
 
     @classmethod
     def _configure_es(cls, config: ConfigParser):
@@ -58,12 +52,7 @@ class TestGrepSearchClass(unittest.TestCase):
     def setUp(self):
         with app.app_context():
             cache.clear()
-        self.grep_search = GrepSearch(
-            config=self.config,
-            es_manager=self.es_manager,
-            modules_es_index=self.es_index,
-            redis_connection=self.redis_connection_mock,
-        )
+        self.grep_search = GrepSearch(config=self.config, es_manager=self.es_manager, modules_es_index=self.es_index)
 
     def tearDown(self):
         with app.app_context():


### PR DESCRIPTION
Started using the ```AUTOCOMPLETE``` ES index, so we would only get ```name```, ```revision```, and ```organization``` in the response. I also started using URL encoding/decoding, so the problem with slashes in responses would disappear.
For now, the response looks like this:
![Screenshot from 2022-12-23 18-30-03](https://user-images.githubusercontent.com/60445869/209375572-5b8a349a-a6ee-42e6-97b5-3f42c5188046.png)
the response took 5.10s for all of the 3264 modules available locally and there are only ~280 modules of them saved in ES, so if there is a bigger percentage of modules saved in ES on prod, then the response will consume less time, and all the next responses would consume less time as well due to caching of the pcregrep command result

resolves #692 