### PR TITLE
feat: add latest-adopted maturity to impact analysis endpoint

### DIFF
--- a/api/views/yangSearch/yangSearch.py
+++ b/api/views/yangSearch/yangSearch.py
@@ -789,6 +789,7 @@ def get_dependencies_dependents_data(
         'organization': module_detail['organization'],
         'reference': module_detail.get('reference', ''),
         'maturity-level': module_detail.get('maturity-level', ''),
-        'expired': module_details.get('expired', 'not-applicable'),
     }
+    if module_detail.get('expired') is False:
+        child['maturity-level'] = 'latest-approved'
     return child


### PR DESCRIPTION
After reviewing the relevant frontend code, I found a way of doing this that wouldn't require frontend changes. This removes the change from #716.