### PR TITLE
fix: set `max-hits`=false if sub-search used

### DIFF
--- a/api/views/yangSearch/yangSearch.py
+++ b/api/views/yangSearch/yangSearch.py
@@ -309,6 +309,8 @@ def search():
     elk_search.construct_query()
     response = {}
     response['rows'], response['max-hits'] = elk_search.search()
+    if payload.get('sub-search'):
+        response['max-hits'] = False
     response['warning'] = elk_search.alerts()
     response['timeout'] = elk_search.timeout
     return make_response(jsonify(response), 200)


### PR DESCRIPTION
Some or all results could have been filtered away by sub-search criteria.
resolves #672