### PR TITLE
chore: remove feb 29 replacement

### DIFF
--- a/api/views/yangSearch/elkSearch.py
+++ b/api/views/yangSearch/elkSearch.py
@@ -200,7 +200,7 @@ class ElkSearch:
             if module_key in reject:
                 continue
 
-            module_latest_revision = self._latest_revisions.get(row.module_name, '').replace('02-29', '02-28')
+            module_latest_revision = self._latest_revisions.get(row.module_name, '')
             if self._search_params.latest_revision and row.revision != module_latest_revision:
                 reject.append(module_key)
                 continue

--- a/api/views/yangSearch/grep_search.py
+++ b/api/views/yangSearch/grep_search.py
@@ -253,7 +253,7 @@ class GrepSearch:
                 response.append(
                     {
                         'module-name': module_data['name'],
-                        'revision': module_data['revision'].replace('02-29', '02-28'),
+                        'revision': module_data['revision'],
                         'organization': module_data['organization'],
                     },
                 )

--- a/api/views/yangSearch/response_row.py
+++ b/api/views/yangSearch/response_row.py
@@ -27,7 +27,7 @@ from utility.staticVariables import OUTPUT_COLUMNS, SDOS
 class ResponseRow:
     def __init__(self, elastic_hit: dict) -> None:
         self.name = elastic_hit['argument']
-        self.revision = elastic_hit['revision'].replace('02-29', '02-28')
+        self.revision = elastic_hit['revision']
         self.schema_type = elastic_hit['statement']
         self.path = elastic_hit['path']
         self.module_name = elastic_hit['module']

--- a/elasticsearchIndexing/pyang_plugin/yang_catalog_index_es.py
+++ b/elasticsearchIndexing/pyang_plugin/yang_catalog_index_es.py
@@ -164,10 +164,7 @@ def index_printer(stmt):
     try:
         dateutil.parser.parse(revision)
     except Exception:
-        if revision[-2:] == '29' and revision[-5:-3] == '02':
-            revision = revision.replace('02-29', '02-28')
-        else:
-            revision = '1970-01-01'
+        revision = '1970-01-01'
     rev_parts = revision.split('-')
     revision = datetime(int(rev_parts[0]), int(rev_parts[1]), int(rev_parts[2])).date().isoformat()
     for i in stmt.substmts:

--- a/parseAndPopulate/integrity.py
+++ b/parseAndPopulate/integrity.py
@@ -70,13 +70,6 @@ def check_revision(parsed_module: Statement) -> bool:
     try:
         date(*revision_parts)
     except ValueError:
-        if revision_parts[1:] == [2, 29]:
-            revision_parts[2] = 28
-            try:
-                date(*revision_parts)
-                return True
-            except ValueError:
-                return False
         return False
     return True
 

--- a/utility/util.py
+++ b/utility/util.py
@@ -487,9 +487,6 @@ def validate_revision(revision: str) -> str:
     Argument:
         :param revision     (str) Revision to validate
     """
-    if '02-29' in revision:
-        revision = revision.replace('02-29', '02-28')
-
     try:
         dateutil.parser.parse(revision)
         year, month, day = map(int, revision.split('-'))


### PR DESCRIPTION
In some cases, replacing feb 29 with feb 28 was just incorrect. In general, writing feb 29 instead of feb 28 isn't more common than any other nonsensial mistake, so we don't have a reason to special case it.