### PR TITLE
feat: improved the grep search

### DIFF
--- a/api/views/yangSearch/json/grep_search.json
+++ b/api/views/yangSearch/json/grep_search.json
@@ -1,9 +1,13 @@
 {
     "query": {
         "bool": {
-            "must": [],
-            "should": [],
-            "minimum_should_match" : 1
+            "filter": [
+                {
+                    "bool": {
+                        "should": []
+                    }
+                }
+            ]
         }
     }
 }

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -58,11 +58,14 @@ class TestGrepSearchClass(unittest.TestCase):
         with app.app_context():
             cache.clear()
 
-    def test_grep_search(self):
+    def test_simple_grep_search(self):
         organizations = []
         simple_search = 'typedef minutes64 {\n.*type uint64;'
         simple_search_result = self.grep_search.search(organizations, simple_search)
         self.assertNotEqual(simple_search_result, [])
+
+    def test_complicated_grep_search(self):
+        organizations = []
         complicated_search = (
             'identity restconf {\n.*base protocol;|typedef email-address {\n.*type string {|'
             'typedef email-address {\n.*type string {\n.*pattern "'
@@ -92,11 +95,13 @@ class TestGrepSearchClass(unittest.TestCase):
         search_result = self.grep_search.search(organizations, search)
         self.assertEqual(search_result, [])
 
-    def test_inverted_grep_search(self):
+    def test_simple_inverted_grep_search(self):
         organizations = ['cisco']
         simple_search = 'organization'
         simple_search_result = self.grep_search.search(organizations, simple_search, inverted_search=True)
         self.assertEqual(simple_search_result, [])
+
+    def test_complicated_inverted_grep_search(self):
         organizations = ['ietf']
         complicated_search = (
             'identity restconf {\n.*base protocol;|typedef email-address {\n.*type string {|'
@@ -109,6 +114,8 @@ class TestGrepSearchClass(unittest.TestCase):
         ]
         self.assertNotIn('yang-catalog@2017-09-26', modules_from_complicated_search_result)
         self.assertNotIn('yang-catalog@2018-04-03', modules_from_complicated_search_result)
+        self.assertIn('semver-test@2020-03-01', modules_from_complicated_search_result)
+        self.assertIn('sdo-module@2022-08-05', modules_from_complicated_search_result)
 
     def test_empty_inverted_grep_search(self):
         organizations = []
@@ -151,7 +158,8 @@ class TestGrepSearchClass(unittest.TestCase):
         organizations = []
         search = 'organization'
         self.grep_search.search(organizations, search)
-        self.assertEqual(
-            self.grep_search.finishing_cursor,
+        finishing_cursor_valid_value = min(
+            self.grep_search.results_per_page,
             len(self.grep_search._get_all_modules_with_filename_extension()),
         )
+        self.assertEqual(self.grep_search.finishing_cursor, finishing_cursor_valid_value)


### PR DESCRIPTION
Fixed and improved the grep search, so from now on, there will be no additional (=incorrect) results because ```term``` used with ```name.keyword``` for module names, I also rewrote the query using the ```filter``` query, so this query won't calculate the relevance score and should be faster, and instead of an Elasticsearch query for every module, there will be maximum the same amount of queries as before, but in the best case scenario, the grep search will only need 1 query for 50 modules (which as we agreed before is enough for one page), but if we need more than that amount in the future then it should be changed carefully because of the limitation to the number of conditions in Elasticsearch

fixes #602 