### PR TITLE
Restore the .json extension on ytree files.

### DIFF
--- a/opensearch_indexing/build_yindex.py
+++ b/opensearch_indexing/build_yindex.py
@@ -70,7 +70,7 @@ def build_indices(
 
     yindexes = json.loads(f.getvalue())
 
-    with open(os.path.join(json_ytree, name_revision), 'w') as writer:
+    with open(os.path.join(json_ytree, name_revision + '.json'), 'w') as writer:
         try:
             emit_tree([parsed_module], writer, ctx)
         except Exception:


### PR DESCRIPTION
This was removed with os.path.join() was introduced.  Other parts of the code expect the files to end in .json.  Without this the JS-based YANG trees are broken.