### PR TITLE
chore: fix linting and tests

### DIFF
--- a/api/views/json_checker.py
+++ b/api/views/json_checker.py
@@ -11,8 +11,7 @@ class Union:
         return ' | '.join(str(m) for m in self.members)
 
 
-class JsonCheckerException(Exception):
-    ...
+class JsonCheckerException(Exception): ...  # noqa: E701
 
 
 class MissingField(JsonCheckerException):

--- a/parseAndPopulate/reviseSemver.py
+++ b/parseAndPopulate/reviseSemver.py
@@ -9,6 +9,7 @@ each module (and all of the revisions).
 Lastly, populate() method will send PATCH request to ConfD and
 cache will be re-loaded using api/load-cache endpoint.
 """
+
 import json
 import os
 import sys

--- a/sandbox/compare_databases.py
+++ b/sandbox/compare_databases.py
@@ -9,6 +9,7 @@ Search and scroll all the documents in the 'modules' index and check whether thi
 is also stored in Redis database
 Finally, all the information are dumped into json file, so they can be reviewed later.
 """
+
 import json
 import os
 

--- a/utility/repoutil.py
+++ b/utility/repoutil.py
@@ -176,7 +176,10 @@ class Worktree:
         try:
             repo_git.worktree('add', self.worktree_dir, branch)
         except GitCommandError as e:
-            if 'is already checked out at' not in e.stderr:
+            conflicting_worktree_exists: bool = (
+                'is already checked out at' in e.stderr or 'is already used by worktree at' in e.stderr
+            )
+            if not conflicting_worktree_exists:
                 raise e
             worktrees_output: list[str] = repo.git.worktree('list', '--porcelain').splitlines()
             conflicting_worktree = None


### PR DESCRIPTION
The PR is to fix

1.  the `check-linting` job (`black`), and
2.  the Python test suite (latest run: https://github.com/YangCatalog/backend/actions/runs/7950238258/job/21702328324)

The latter was introduced by an external dependency, `git`. I was only able to reproduce the error locally after upgrading `git` to a newer version.

``` bash
git --version
```

``` text
git version 2.43.0
```

``` python
YANGCATALOG_CONFIG_PATH="$(pwd)/tests/resources/test.conf" BACKEND="$(pwd)" \
    python -m unittest tests.test_repoutil.TestWorktree.test_create_worktree_if_one_already_exists
```

``` text
E
======================================================================
ERROR: test_create_worktree_if_one_already_exists (tests.test_repoutil.TestWorktree.test_create_worktree_if_one_already_exists)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sanghoietf/src/github.com/YangCatalog/backend/tests/test_repoutil.py", line 113, in test_create_worktree_if_one_already_exists
    wt2 = self._create_worktree()
          ^^^^^^^^^^^^^^^^^^^^^^^

...

----------------------------------------------------------------------
Ran 1 test in 6.565s

FAILED (errors=1)
```

Currently, `repoutil.Worktree` relies on the error message produced by Git to determine if there is any conflicting worktree. However, the format of the error message has recently changed, causing the build to fail. See <https://github.com/git/git/commit/2a499264d39> for more info. The fix should work with both older and newer versions of Git.
