### PR TITLE
ci: add semantic check config

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,3 @@
+enabled: true
+titleOnly: true
+targetUrl: "https://www.conventionalcommits.org/en/v1.0.0/#summary"


### PR DESCRIPTION
Adding a checker for [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), which is also used in `ietf-tools` repos 

e.g. https://github.com/ietf-tools/datatracker/blob/main/.github/semantic.yml