### PR TITLE
5.17.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Backend Release Notes
 
+* ##### v5.17.0 - 2023-12-11
+
+  * Added 2 new endpoints for prototype redis-editing page [frontend #39](https://github.com/YangCatalog/frontend/issues/39)
+
 * ##### v5.16.0 - 2023-11-08
 
   * Added fix for Impact Analysis page internal server error [frontend #38](https://github.com/YangCatalog/frontend/issues/38)

--- a/api/views/admin.py
+++ b/api/views/admin.py
@@ -17,9 +17,11 @@ __copyright__ = 'Copyright The IETF Trust 2020, All Rights Reserved'
 __license__ = 'Apache License, Version 2.0'
 __email__ = 'miroslav.kovac@pantheon.tech'
 
+import collections
 import fnmatch
 import grp
 import gzip
+import json
 import math
 import os
 import pwd
@@ -35,11 +37,13 @@ import flask
 from flask.blueprints import Blueprint
 from flask.globals import request
 from flask.json import jsonify
+from flask.wrappers import Response
 from flask_cors import CORS
 from flask_pyoidc import OIDCAuthentication
 from flask_pyoidc.provider_configuration import ClientMetadata, ProviderConfiguration
 from flask_pyoidc.user_session import UserSession
 from redis import RedisError
+from typing_extensions import Tuple
 from werkzeug.exceptions import abort
 from werkzeug.utils import redirect
 
@@ -606,3 +610,29 @@ def get_input(body):
         abort(400, description='bad-request - body has to start with "input" and can not be empty')
     else:
         return body['input']
+
+
+@bp.route('/api/admin/module/<module>@<revision>/<organization>', methods=['GET'])
+@catch_db_error
+def get_redis_module(module: str, revision: str, organization: str) -> dict | Tuple[Response, int]:
+    module_key = f'{module}@{revision}/{organization}'
+    module_from_db = app.redisConnection.get_module(module_key)
+    if module_from_db != '{}':
+        return json.JSONDecoder(object_pairs_hook=collections.OrderedDict).decode(module_from_db)
+    else:
+        return jsonify({module_key: {'info': 'Module does not exist.'}}), 404
+
+
+@bp.route('/api/admin/module/<module>@<revision>/<organization>', methods=['PUT'])
+@catch_db_error
+def update_redis_module(module: str, revision: str, organization: str) -> dict | Tuple[Response, int]:
+    module_key = f'{module}@{revision}/{organization}'
+    module_from_db = app.redisConnection.get_module(module_key)
+    module_to_json = json.JSONDecoder(object_pairs_hook=collections.OrderedDict).decode(module_from_db)
+    if body := request.get_json():
+        if body == module_to_json:
+            return jsonify({'message': f'Module {module_key} is already in database.'}), 200
+        app.redisConnection.set_module(body, module_key)
+        return jsonify({'message': f'Module {module_key} updated successfully.'}), 200
+    else:
+        return jsonify({'error': 'Invalid data provided.'}), 400


### PR DESCRIPTION
The previous release from December 2023 hasn't been merged back to `master`. 

Please note the commit with the release notes (`c899590`) had already been merged into `develop` _before_ the one with actual changes (`9b099c7`), so the version will be tagged (with `v5.17.0`) on the merge commit below (`a7db1d7`).

```
a7db1d7 *   v5.17.0 origin/v5.17.0 merged with develop
        |\
9b099c7 | * feature: introduced 2 new endpoints for admin UI (#806)
c899590 * | 5.17.0 Release
        |/
fbd9241 * v5.16.0 origin/master 5.16.0 Release
```

Please note that the PR will not be squashed otherwise it will generate a new hash that's different from what's already there in the `develop` branch.