### PR TITLE
Release/v5.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Backend Release Notes
 
+* ##### v5.18.0 - 2024-02-26
+
+  * Restore the .json extension on ytree files [backend #816](https://github.com/YangCatalog/backend/pull/816)
+  * Ignore a missing module revision [backend #820](https://github.com/YangCatalog/backend/pull/820)
+  * Ignore errors on modules that don't exist [backend #821](https://github.com/YangCatalog/backend/pull/821)
+  * Always use rebase when pulling [backend #818](https://github.com/YangCatalog/backend/pull/818) [module-compilation #294](https://github.com/YangCatalog/module-compilation/pull/294)
+  * Remove legacy IPs [backend #817](https://github.com/YangCatalog/backend/pull/817) [yang-validator-extractor #151](https://github.com/YangCatalog/yang-validator-extractor/pull/151)
+  * Start postfix as root [deployment #208](https://github.com/YangCatalog/deployment/pull/208)
+  * Remove redundant healthcheck [deployment #209](https://github.com/YangCatalog/deployment/pull/209)
+
 * ##### v5.17.0 - 2023-12-11
 
   * Added 2 new endpoints for prototype redis-editing page [frontend #39](https://github.com/YangCatalog/frontend/issues/39)

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ WORKDIR $VIRTUAL_ENV
 # Apply cron job
 RUN crontab /etc/cron.d/yang-cron
 
+# Enforce rebase pulls
+RUN /usr/bin/git config --global pull.rebase true
+
 USER root:root
 CMD cron && service postfix start && service rsyslog start && /backend/bin/gunicorn api.wsgi:application -c gunicorn.conf.py
 

--- a/api/globalConfig.py
+++ b/api/globalConfig.py
@@ -36,7 +36,7 @@ class YangCatalogApiGlobalConfig:
 
     def load_config(self):
         config = create_config()
-        self.secret_key = config.get('Secrets-Section', 'flask-secret-key', fallback='S3CR3T!')
+        self.secret_key = config.get('Secrets-Section', 'flask-secret-key', fallback='FLASKS3CR3T')
         self.nginx_dir = config.get('Directory-Section', 'nginx-conf', fallback='')
         self.result_dir = config.get('Web-Section', 'result-html-dir', fallback='tests/resources/html/results')
         self.private_dir = config.get('Web-Section', 'private-directory', fallback='tests/resources/html/private')
@@ -85,7 +85,7 @@ class YangCatalogApiGlobalConfig:
         self.domain_prefix = config.get('Web-Section', 'domain-prefix', fallback='http://localhost')
         self.opensearch_aws = self.opensearch_aws == 'True'
 
-        self.LOGGER = log.get_logger('api.yc_gc', '{}/yang.log'.format(self.logs_dir))
+        self.LOGGER = log.get_logger('api.yc_gc', f'{self.logs_dir}/yang.log')
 
         self.LOGGER.info('yangcatalog configuration reloaded')
         self.redis = redis.Redis(host=self.redis_host, port=self.redis_port)  # pyright: ignore

--- a/api/views/health_check.py
+++ b/api/views/health_check.py
@@ -466,10 +466,6 @@ def health_check_yangcatalog():
         {'url': 'http://www.yangvalidator.com', 'verify': True},
         {'url': 'https://yangvalidator.com', 'verify': True},
         {'url': 'https://www.yangvalidator.com', 'verify': True},
-        {'url': 'http://18.224.127.129', 'verify': False},
-        {'url': 'https://18.224.127.129', 'verify': False},
-        {'url': 'http://[2600:1f16:ba:200:a10d:3212:e763:e720]', 'verify': False},
-        {'url': 'https://[2600:1f16:ba:200:a10d:3212:e763:e720]', 'verify': False},
     ]
 
     for item in urls:

--- a/api/views/yang_search/yang_search.py
+++ b/api/views/yang_search/yang_search.py
@@ -502,9 +502,11 @@ def module_details(module: str, selected_revision: t.Optional[str] = None, warni
         module_key = f'{module}@{revision}/{organization}'
         module_data = app.redisConnection.get_module(module_key)
         if module_data == '{}':
-            if warnings:
-                return {'warning': f'module {module_key} does not exist in API'}
-            abort(404, description='Provided module does not exist')
+            if selected_revision == revision:
+                abort(404, description=f'module {module_key} does not exist in redis (found in search index)')
+            else:
+                bp.logger.warning(f'module {module_key} does not exist in redis (found in search index)')
+                continue
         module_data = json.loads(module_data)
         rev_mat_pair = {
             'revision': module_data['revision'],

--- a/opensearch_indexing/build_yindex.py
+++ b/opensearch_indexing/build_yindex.py
@@ -70,7 +70,7 @@ def build_indices(
 
     yindexes = json.loads(f.getvalue())
 
-    with open(os.path.join(json_ytree, name_revision), 'w') as writer:
+    with open(os.path.join(json_ytree, name_revision + '.json'), 'w') as writer:
         try:
             emit_tree([parsed_module], writer, ctx)
         except Exception:

--- a/parseAndPopulate/modulesComplicatedAlgorithms.py
+++ b/parseAndPopulate/modulesComplicatedAlgorithms.py
@@ -425,8 +425,12 @@ class ModulesComplicatedAlgorithms:
                 ctx.opts.lint_modulename_prefixes = []
                 for p in plugin.plugins:
                     p.setup_ctx(ctx)
-                with open(self._path, 'r', errors='ignore') as f:
-                    a = ctx.add_module(self._path, f.read())
+                try:
+                    with open(self._path, 'r', errors='ignore') as f:
+                        a = ctx.add_module(self._path, f.read())
+                except Exception as e:
+                    LOGGER.debug("Error opening %s: %s" % self._path, str(e))
+                    a = None
                 if a is None:
                     LOGGER.debug(
                         f'Could not use pyang to generate tree because of errors on module {self._path}',

--- a/tests/resources/test.conf
+++ b/tests/resources/test.conf
@@ -8,9 +8,9 @@ repo-config-name=test
 repo-config-email=test_email@example.com
 
 [Secrets-Section]
-flask-secret-key=S3CR3T
+flask-secret-key=FLASKS3CR3T
 rabbitmq-password=rabbitmq
-opensearch-secret=test
+opensearch-secret='test test'
 confd-credentials='test test'
 yang-catalog-token=test
 admin-token=test


### PR DESCRIPTION
Now that https://github.com/YangCatalog/backend/pull/824 (release notes for `v5.18.0`) has landed in `develop`, the next step is to merge all changes associated with the release into `master`. Once merged, it will be tagged accordingly.

Note to self: We need to retain the commit hashes, so do _not_ squash the commits. 

See also: https://github.com/YangCatalog/backend/pull/823