### PR TITLE
chore: Ignore Q000 in flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,5 +3,5 @@ exclude=.git,__pycache__,docs/source/conf.py,old,build,dist,venv,__init__.py,./l
 inline-quotes='
 max-line-length=120
 select=E,F,W,C4,Q0,N80,ABS,W504
-ignore=W503,Q003,C417
+ignore=W503,Q000,Q003,C417
 extend-ignore=E203

--- a/parseAndPopulate/modulesComplicatedAlgorithms.py
+++ b/parseAndPopulate/modulesComplicatedAlgorithms.py
@@ -429,7 +429,7 @@ class ModulesComplicatedAlgorithms:
                     with open(self._path, 'r', errors='ignore') as f:
                         a = ctx.add_module(self._path, f.read())
                 except Exception as e:
-                    LOGGER.debug('Error opening %s: %s' % self._path, str(e))
+                    LOGGER.debug("Error opening %s: %s" % self._path, str(e))
                     a = None
                 if a is None:
                     LOGGER.debug(

--- a/parseAndPopulate/modulesComplicatedAlgorithms.py
+++ b/parseAndPopulate/modulesComplicatedAlgorithms.py
@@ -429,7 +429,7 @@ class ModulesComplicatedAlgorithms:
                     with open(self._path, 'r', errors='ignore') as f:
                         a = ctx.add_module(self._path, f.read())
                 except Exception as e:
-                    LOGGER.debug("Error opening %s: %s" % self._path, str(e))
+                    LOGGER.debug('Error opening %s: %s' % self._path, str(e))
                     a = None
                 if a is None:
                     LOGGER.debug(


### PR DESCRIPTION
~Use single quotes for Python strings to fix the flake8 error.~

```text
./parseAndPopulate/modulesComplicatedAlgorithms.py:432:34: Q000 Double quotes found but single quotes preferred
Error: Process completed with exit code 1.
```

**Update**: `flake8` doesn't seem to support `black` as profile, like `isort` does. Going forward, we'll choose `black`'s formatting over `flake8`'s when there is a conflict between the two.