### PR TITLE
fix: Docker build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN chown -R yang:yang /usr/share/nginx
 RUN ln -s /usr/share/nginx/html/stats/statistics.html /usr/share/nginx/html/statistics.html
 
 COPY ./backend/requirements.txt .
+RUN python -m pip install "pip<24.1"
 RUN pip install -r requirements.txt
 
 COPY --chown=yang:yang ./backend $VIRTUAL_ENV
@@ -66,10 +67,11 @@ WORKDIR $VIRTUAL_ENV
 # Apply cron job
 RUN crontab /etc/cron.d/yang-cron
 
+USER root:root
+
 # Enforce rebase pulls
 RUN /usr/bin/git config --global pull.rebase true
 
-USER root:root
 CMD cron && service postfix start && service rsyslog start && /backend/bin/gunicorn api.wsgi:application -c gunicorn.conf.py
 
 EXPOSE 3031


### PR DESCRIPTION
- downgraded pip due to celery having broken metadata and new versions of pip enforcing working metadata
   - fixes the following:
```
4.695 Collecting celery==4.4.7 (from -r requirements.txt (line 32))
4.712   Downloading celery-4.4.7-py2.py3-none-any.whl.metadata (19 kB)
4.724 WARNING: Ignoring version 4.4.7 of celery since it has invalid metadata:
4.724 Requested celery==4.4.7 from https://files.pythonhosted.org/packages/c8/0c/609e3611d20c9f8d883852d1be5516671f630fb08c8c1e56911567dfba7b/celery-4.4.7-py2.py3-none-any.whl (from -r requirements.txt (line 32)) has invalid metadata: Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
4.724     pytz (>dev)
4.724          ~^
4.724 Please use pip<24.1 if you need to use this version.
4.726 ERROR: Ignored the following yanked versions: 5.0.6, 5.2.5
4.727 ERROR: Could not find a version that satisfies the requirement celery==4.4.7 (from versions: 0.1.2, 0.1.4, 0.1.6, 0.1.7, 0.1.8, 0.1.10, 0.1.11, 0.1.12, 0.1.13, 0.1.14, 0.1.15, 0.2.0, 0.3.0, 0.3.7, 0.3.20, 0.4.0, 0.4.1, 0.6.0, 0.8.0, 0.8.1, 0.8.2, 0.8.3, 0.8.4, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.1.0, 2.1.1, 2.1.2, 2.1.3, 2.1.4, 2.2.0, 2.2.1, 2.2.2, 2.2.3, 2.2.4, 2.2.5, 2.2.6, 2.2.7, 2.2.8, 2.2.9, 2.2.10, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.3.5, 2.4.0, 2.4.1, 2.4.2, 2.4.3, 2.4.4, 2.4.5, 2.4.6, 2.4.7, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.5.5, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.0.5, 3.0.6, 3.0.7, 3.0.8, 3.0.9, 3.0.10, 3.0.11, 3.0.12, 3.0.13, 3.0.14, 3.0.15, 3.0.16, 3.0.17, 3.0.18, 3.0.19, 3.0.20, 3.0.21, 3.0.22, 3.0.23, 3.0.24, 3.0.25, 3.1.0, 3.1.1, 3.1.2, 3.1.3, 3.1.4, 3.1.5, 3.1.6, 3.1.7, 3.1.8, 3.1.9, 3.1.10, 3.1.11, 3.1.12, 3.1.13, 3.1.14, 3.1.15, 3.1.16, 3.1.17, 3.1.18, 3.1.19, 3.1.20, 3.1.21, 3.1.22, 3.1.23, 3.1.24, 3.1.25, 3.1.26.post1, 3.1.26.post2, 4.0.0rc3, 4.0.0rc4, 4.0.0rc5, 4.0.0rc6, 4.0.0rc7, 4.0.0, 4.0.1, 4.0.2, 4.1.0, 4.1.1, 4.2.0rc1, 4.2.0rc2, 4.2.0rc3, 4.2.0rc4, 4.2.0, 4.2.1, 4.2.2, 4.3.0rc1, 4.3.0rc2, 4.3.0rc3, 4.3.0, 4.3.1, 4.4.0rc1, 4.4.0rc2, 4.4.0rc3, 4.4.0rc4, 4.4.0rc5, 4.4.0, 4.4.1, 4.4.2, 4.4.3, 4.4.4, 4.4.5, 4.4.6, 4.4.7, 5.0.0a1, 5.0.0a2, 5.0.0b1, 5.0.0rc1, 5.0.0rc2, 5.0.0rc3, 5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.1.0b1, 5.1.0b2, 5.1.0rc1, 5.1.0, 5.1.1, 5.1.2, 5.2.0b1, 5.2.0b2, 5.2.0b3, 5.2.0rc1, 5.2.0rc2, 5.2.0, 5.2.1, 5.2.2, 5.2.3, 5.2.4, 5.2.6, 5.2.7, 5.3.0a1, 5.3.0b1, 5.3.0b2, 5.3.0rc1, 5.3.0rc2, 5.3.0, 5.3.1, 5.3.4, 5.3.5, 5.3.6, 5.4.0rc1, 5.4.0rc2, 5.4.0, 5.5.0b1, 5.5.0b2, 5.5.0b3, 5.5.0b4, 5.5.0rc1, 5.5.0rc2, 5.5.0rc3)
4.821 ERROR: No matching distribution found for celery==4.4.7
------
failed to solve: process "/bin/sh -c pip install -r requirements.txt" did not complete successfully: exit code: 1
```
 - fixed docker compose build failing on git config --global due to not being root
    - fixes the following:
```
 => ERROR [backend 25/25] RUN /usr/bin/git config --global pull.rebase true                                                                            0.4s
------
 > [backend 25/25] RUN /usr/bin/git config --global pull.rebase true:
0.295 error: could not lock config file /backend/.gitconfig: Permission denied
------
failed to solve: process "/bin/sh -c /usr/bin/git config --global pull.rebase true" did not complete successfully: exit code: 255
```